### PR TITLE
Add secrets policies

### DIFF
--- a/secrets/secrets-custom-ec2-custom-role-policy.json
+++ b/secrets/secrets-custom-ec2-custom-role-policy.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowECSTaskAssumption",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/secrets/secrets-custom-ec2-execution-role.json
+++ b/secrets/secrets-custom-ec2-execution-role.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowNextflowHeadJobToAccessSecrets",
+            "Effect": "Allow",
+            "Action": "secretsmanager:ListSecrets",
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowNextflowHeadJobToPassRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:PassRole"
+            ],
+            "Resource": "arn:aws:iam::YOUR_ACCOUNT:role/YOUR_BATCH_CLUSTER-ExecutionRole"
+        }
+    ]
+}

--- a/secrets/secrets-ec2-instance-role.json
+++ b/secrets/secrets-ec2-instance-role.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowNextflowHeadJobToAccessSecrets",
+            "Effect": "Allow",
+            "Action": "secretsmanager:ListSecrets",
+            "Resource": "*"
+        }
+    ]
+}

--- a/secrets/secrets-ecs-execution-role.json
+++ b/secrets/secrets-ecs-execution-role.json
@@ -1,0 +1,15 @@
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowECSAgentToRetrieveSecrets",
+                "Action": [
+                    "secretsmanager:GetSecretValue"
+                ],
+                "Resource": [
+                    "arn:aws:secretsmanager:<YOUR_COMPUTE_REGION>:*:secret:*"
+                ],
+                "Effect": "Allow"
+            }
+        ]
+    }

--- a/secrets/secrets-ecs-trust-relationship.json
+++ b/secrets/secrets-ecs-trust-relationship.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowECSTaskAssumption",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/secrets/secrets-tower-instance.json
+++ b/secrets/secrets-tower-instance.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowTowerEnterpriseSecrets",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:DeleteSecret",
+                "secretsmanager:ListSecrets",
+                "secretsmanager:CreateSecret"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
Add 3 permissions policies for AWS Secrets Manager:
- Tower instance role
- ECS execution role
- ECS IAM trust relationship
- EC2 custom role
- EC2 custom trust policy

These policies are added to align with Tower docs updates in https://github.com/seqeralabs/nf-tower-docs/pull/350 

The necessity to delete the existing secrets policies in this repo is to be determined. 