### PR TITLE
Add Cloudwatch agent config for manual AWS CEs

### DIFF
--- a/cloudwatch-config/README.md
+++ b/cloudwatch-config/README.md
@@ -1,0 +1,3 @@
+# Amazon Cloudwatch Agent configuration file
+
+A configuration file for Cloudwatch Agent, retrieved by the custom launch template used in manual AWS Batch compute environments in Seqera Platform. See [Manual AWS Batch configuration](https://docs.seqera.io/platform/latest/enterprise/advanced-topics/manual-aws-batch-setup) for more information.

--- a/cloudwatch-config/agent-config.json
+++ b/cloudwatch-config/agent-config.json
@@ -8,33 +8,33 @@
         "files":{
            "collect_list":[
               {
-                 "file_path":"/var/log/tower-ce.log",
-                 "log_group_name":"tower/ce",
-                 "log_stream_name":"ce/{instance_id}",
+                 "file_path":"/var/log/seqera-ce.log",
+                 "log_group_name":"seqera/ce",
+                 "log_stream_name":"seqera-prefix/ce/{instance_id}",
                  "retention_in_days": 7
               },
               {
                  "file_path":"/var/log/ebs-autoscale.log",
-                 "log_group_name":"tower/ebs-autoscale",
-                 "log_stream_name":"ebs-autoscale/{instance_id}",
+                 "log_group_name":"seqera/ebs-autoscale",
+                 "log_stream_name":"seqera-prefix/ebs-autoscale/{instance_id}",
                  "retention_in_days": 7
               },
               {
                  "file_path":"/var/log/cloud-init.log",
-                 "log_group_name":"tower/cloud-init",
-                 "log_stream_name":"cloud-init/{instance_id}",
+                 "log_group_name":"seqera/cloud-init",
+                 "log_stream_name":"seqera-prefix/cloud-init/{instance_id}",
                  "retention_in_days": 7
               },
               {
                  "file_path":"/var/log/cloud-init-output.log",
-                 "log_group_name":"tower/cloud-init-output",
-                 "log_stream_name":"cloud-init-output/{instance_id}",
+                 "log_group_name":"seqera/cloud-init-output",
+                 "log_stream_name":"seqera-prefix/cloud-init-output/{instance_id}",
                  "retention_in_days": 7
               },
               {
                  "file_path":"/var/log/ecs/ecs-agent.log",
-                 "log_group_name":"tower/ecs-agent",
-                 "log_stream_name":"ecs-agent/{instance_id}",
+                 "log_group_name":"seqera/ecs-agent",
+                 "log_stream_name":"seqera-prefix/ecs-agent/{instance_id}",
                  "retention_in_days": 7
               }
            ]

--- a/cloudwatch-config/agent-config.json
+++ b/cloudwatch-config/agent-config.json
@@ -1,0 +1,44 @@
+{
+  "agent":{
+     "metrics_collection_interval":60,
+     "run_as_user":"root"
+  },
+  "logs":{
+     "logs_collected":{
+        "files":{
+           "collect_list":[
+              {
+                 "file_path":"/var/log/tower-ce.log",
+                 "log_group_name":"tower/ce",
+                 "log_stream_name":"ce/{instance_id}",
+                 "retention_in_days": 7
+              },
+              {
+                 "file_path":"/var/log/ebs-autoscale.log",
+                 "log_group_name":"tower/ebs-autoscale",
+                 "log_stream_name":"ebs-autoscale/{instance_id}",
+                 "retention_in_days": 7
+              },
+              {
+                 "file_path":"/var/log/cloud-init.log",
+                 "log_group_name":"tower/cloud-init",
+                 "log_stream_name":"cloud-init/{instance_id}",
+                 "retention_in_days": 7
+              },
+              {
+                 "file_path":"/var/log/cloud-init-output.log",
+                 "log_group_name":"tower/cloud-init-output",
+                 "log_stream_name":"cloud-init-output/{instance_id}",
+                 "retention_in_days": 7
+              },
+              {
+                 "file_path":"/var/log/ecs/ecs-agent.log",
+                 "log_group_name":"tower/ecs-agent",
+                 "log_stream_name":"ecs-agent/{instance_id}",
+                 "retention_in_days": 7
+              }
+           ]
+        }
+     }
+  }
+}


### PR DESCRIPTION
Adds a Cloudwatch Agent configuration file to be retrieved by the custom launch templates provided for manual AWS Batch compute environments. 

Related to https://github.com/seqeralabs/docs/pull/103