### PR TITLE
Add a new policy to make requirements for the data explorer

### DIFF
--- a/data/data-explorer-policy.json
+++ b/data/data-explorer-policy.json
@@ -8,7 +8,7 @@
 				"s3:PutObject",
 				"s3:GetObject"
 			],
-			"Resource": "*"
+			"Resource": "arn:aws:s3:::*"
 			// Note: The above resource can be scoped one or more a specific buckets or bucket prefixes, for example:
 			// "Resource": "arn:aws:s3:::seqera-showcase/*"
 		}

--- a/data/data-explorer-policy.json
+++ b/data/data-explorer-policy.json
@@ -1,0 +1,16 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "DataExplorer0",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:GetObject"
+			],
+			"Resource": "*"
+			// Note: The above resource can be scoped one or more a specific buckets or bucket prefixes, for example:
+			// "Resource": "arn:aws:s3:::seqera-showcase/*"
+		}
+	]
+}


### PR DESCRIPTION
If a user creates an IAM user using the forge policy, they will be unable to upload data using Data Explorer. This minimal policy can be added to the IAM user that is added to the workspace.