### PR TITLE
FSN-488: Document AWS Cloud IAM permissions

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,79 @@
+# AWS Cloud ComputeEnvironment IAM permission
+
+To configure a Seqera AWS Cloud compute environment, AWS credentials need to be provisioned beforehand in your AWS account for the compute environment creation and pipeline launch to work. The CloudFormation template in [template.yaml](template.yaml) can be used to provision such resources, or you could manually create the user and assign the policies you can find in the [policy.json](policy.json) file.
+
+> [!NOTE]
+> These permission give start access to resources to cover most of the use cases. You can restrict those according to resource naming or tag conditons depending on your conventions.
+
+## Cloudformation template
+
+### Created resources
+
+The template will deploy the following resources:
+- An IAM user
+- Access keys for the created user
+- An IAM Role that can be assumed by the created user, with IAM Inline Policies attached to grant enough permissions
+
+### Accepted parameters
+
+The following parameters are accepted to customise the names of the resources created:
+
+- IAMUserName: will define the name of the IAM user created, defaults to `SeqeraPlatform`.
+- RoleName: will define the name of the IAM role to be assumed, defaults to `SeqeraPlatformRole`.
+
+### Generated Output
+
+The stack will make available as output the following information:
+
+- SeqeraPlatformUserAccessKeyId: the AWS Access Key for the created user.
+- SeqeraPlatformUserSecretAccessKey: the AWS Secret Access Key for the created user.
+- SeqeraPlatformRole: the IAM role to be assumed by the user to work with the AWS Cloud CE.
+
+## Usage
+
+There are 2 ways to provision resources using this template: through the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) or through the [AWS console](https://aws.amazon.com/console/).
+
+### Usage with AWS CLI
+
+To create the stack through the AWS CLI, download the file [template.yaml](template.yaml) on your machine, and from the same directory run:
+
+```bash
+aws cloudformation create-stack --stack-name seqera-aws-cloud-bootstrap --template-body file://template.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+
+> [!NOTE]
+> --capabilities CAPABILITY_NAMED_IAM is necessary to acknowledge the fact this template will create and manage IAM resources.
+
+If you want to customise any of the parameters, you can pass them to the aws cli command following its convetion. For example to customise the IAM user name and IAM role name you can create the stack with the following:
+
+```bash
+aws cloudformation create-stack --stack-name seqera-aws-cloud-bootstrap --template-body file://template.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameters ParameterKey=IAMUserName,ParameterValue=MyCustomIAMUserName ParameterKey=RoleName,ParameterValue=MyCustomIAMRoleName
+```
+
+If you wish to make any modification to the resources after they are created, you can run the update command after modifying the template
+
+```bash
+aws cloudformation update-stack --stack-name seqera-aws-cloud-bootstrap --template-body file://template.yaml --capabilities CAPABILITY_NAMED_IAM
+```
+
+To see the output in your console you can run
+
+```bash
+aws cloudformation describe-stacks --stack-name seqera-aws-cloud-bootstrap --query "Stacks[0].Outputs"
+```
+
+To delete the resources created with this stack, you can run:
+
+```bash
+aws cloudformation delete-stack --stack-name seqera-aws-cloud-bootstrap
+```
+
+### Usage with AWS Console
+
+You can imprort the template directly in the AWS Console if you're not comfortable with the aws cli. AWS has extensive documentation on how to do [Create a stack from the CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html).
+
+## JSON IAM policy
+
+If you don't feel comfortable managing this through CloudFormation, you can find a policy expressed in JSON format in [policy.json] that you can attach manually to a role or a user.

--- a/cloud/policy.json
+++ b/cloud/policy.json
@@ -32,7 +32,7 @@
             "Effect": "Allow",
             "Action": [
                 "ec2:RunInstances",
-                "ec2:DescribeInstance",
+                "ec2:DescribeInstances",
                 "ec2:CreateTags",
                 "ec2:TerminateInstance",
                 "ec2:DeleteTags",

--- a/cloud/policy.json
+++ b/cloud/policy.json
@@ -1,0 +1,74 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AwsCloudCreate",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:AddRoleToInstanceProfile",
+                "iam:CreateInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:PassRole",
+                "iam:TagRole",
+                "iam:TagInstanceProfile"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AwsCloudValidate",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeImages",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AwsCloudLaunch",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances",
+                "ec2:DescribeInstance",
+                "ec2:CreateTags",
+                "ec2:TerminateInstance",
+                "ec2:DeleteTags",
+                "logs:GetLogEvents",
+                "s3:GetObject"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AwsCloudDelete",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:DeleteRole",
+                "iam:DeleteInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DetachRolePolicy",
+                "iam:DeleteRolePolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AwsCloudRead",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeKeyPairs",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeImages",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/cloud/policy.json
+++ b/cloud/policy.json
@@ -34,7 +34,7 @@
                 "ec2:RunInstances",
                 "ec2:DescribeInstances",
                 "ec2:CreateTags",
-                "ec2:TerminateInstance",
+                "ec2:TerminateInstances",
                 "ec2:DeleteTags",
                 "logs:GetLogEvents",
                 "s3:GetObject"

--- a/cloud/template.yaml
+++ b/cloud/template.yaml
@@ -1,0 +1,126 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  IAMUserName:
+    Description: Enter the name for the IAM user that will be created for the Seqera Platform
+    Type: String
+    Default: SeqeraPlatform
+  RoleName:
+    Description: Enter the name for the IAM role that will be assumed by the Seqera Platform IAM user
+    Type: String
+    Default: SeqeraPlatformRole
+
+Resources:
+  SeqeraPlatformUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      UserName: !Ref IAMUserName
+  SeqeraPlatformRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt SeqeraPlatformUser.Arn
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        # Permissions necessary to create resources for the AWS Cloud Compute environment.
+        - PolicyName: SeqeraAWSCloudCreate
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Sid: AWSCloudCreate
+                Action:
+                  - iam:CreateRole
+                  - iam:AddRoleToInstanceProfile
+                  - iam:CreateInstanceProfile
+                  - iam:AttachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:PassRole
+                  - iam:TagRole
+                  - iam:TagInstanceProfile
+                Resource: '*'
+        # Permissions necessary to validate the AWS Cloud compute environment configuration at creation time.
+        - PolicyName: SeqeraAWSCloudValidate
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Sid: AWSCloudValidate
+                Action:
+                  - ec2:DescribeInstanceTypes
+                  - ec2:DescribeImages
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeSecurityGroups
+                Resource: '*'
+        # Permissions necessary to launch, monitor and stop Nextflow pipelines / Studio sessions on the AWS Cloud compute environment.
+        - PolicyName: AWSCloudLaunch
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Sid: AWSCloudLaunch
+                Action:
+                  - ec2:RunInstances
+                  - ec2:DescribeInstance
+                  - ec2:CreateTags
+                  - ec2:DeleteTags
+                  - ec2:TerminateInstance
+                  - logs:GetLogEvents
+                  - s3:GetObject
+                Resource: '*'
+        # Permissions necessary to delete AWS resources when deleting a Compute Environment.
+        - PolicyName: SeqeraAWSCloudDelete
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Sid: AWSCloudDelete
+                Action:
+                  - iam:GetRole
+                  - iam:ListAttachedRolePolicies
+                  - iam:ListRolePolicies
+                  - iam:DeleteRole
+                  - iam:DeleteInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:DetachRolePolicy
+                  - iam:DeleteRolePolicy
+                Resource: '*'
+        # Permissions to read AWS resource information to show fill in options in the UI.
+        - PolicyName: SeqeraAWSCloudRead
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Sid: AWSCloudRead
+                Action:
+                  - ec2:DescribeInstanceTypes
+                  - ec2:DescribeKeyPairs
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeImages
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeSecurityGroups
+                  - s3:ListAllMyBuckets
+                Resource: '*'
+      RoleName: !Ref RoleName
+  SeqeraPlatformAccessKeys:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      Status: Active
+      UserName: !Ref SeqeraPlatformUser
+
+Outputs:
+  SeqeraPlatoformUserAccessKeyId:
+    Description: The User access key to upload to Seqera Platform as credentials
+    Value: !Ref SeqeraPlatformAccessKeys
+  SeqeraPlatoformUserSecretAccessKey:
+    Description: The User secret access key to upload to Seqera Platform as credentials
+    Value: !GetAtt SeqeraPlatformAccessKeys.SecretAccessKey
+  SeqeraPlatoformRole:
+    Description: The role to be assumed by Seqera Platform to create and use the AWS Cloud credentials
+    Value: !GetAtt SeqeraPlatformRole.Arn

--- a/cloud/template.yaml
+++ b/cloud/template.yaml
@@ -70,7 +70,7 @@ Resources:
                   - ec2:DescribeInstances
                   - ec2:CreateTags
                   - ec2:DeleteTags
-                  - ec2:TerminateInstance
+                  - ec2:TerminateInstances
                   - logs:GetLogEvents
                   - s3:GetObject
                 Resource: '*'

--- a/cloud/template.yaml
+++ b/cloud/template.yaml
@@ -67,7 +67,7 @@ Resources:
                 Sid: AWSCloudLaunch
                 Action:
                   - ec2:RunInstances
-                  - ec2:DescribeInstance
+                  - ec2:DescribeInstances
                   - ec2:CreateTags
                   - ec2:DeleteTags
                   - ec2:TerminateInstance


### PR DESCRIPTION
Document the permission needed for Platform credentials to smoothly use the new AWS Cloud compute environment.
Create both a JSON version of the needed policies for manual provisioning and a CloudFormation template to enable IaC
management of the user and permissions.